### PR TITLE
Fixups to run 07-bling/WKBDEEP locally

### DIFF
--- a/07-bling/gadget3 - WKBDEEP/00-setup/setup-catchdistribution.R
+++ b/07-bling/gadget3 - WKBDEEP/00-setup/setup-catchdistribution.R
@@ -115,6 +115,7 @@ aldist.bmt <-
                                                   open_ended = c("upper","lower"))),
                       defaults))
 
+library(mar)
 mar <- connect_mar()
 
 ldist.is <-

--- a/07-bling/gadget3 - WKBDEEP/00-setup/setup-fleets.R
+++ b/07-bling/gadget3 - WKBDEEP/00-setup/setup-fleets.R
@@ -51,7 +51,6 @@ quota <-
       ),
     year_length = 1L,
     start_step = 3L,
-    init_val = 0,
     run_revstep = -2,
     run_f = quote(cur_year >= end_year - 1),
     )

--- a/07-bling/gadget3 - WKBDEEP/00-setup/setup-initial_parameters.R
+++ b/07-bling/gadget3 - WKBDEEP/00-setup/setup-initial_parameters.R
@@ -54,6 +54,7 @@ init.sigma <-
   dplyr::group_by(age) %>% 
   dplyr::summarise(ml=mean(length,na.rm=TRUE),ms=sd(length,na.rm=TRUE), n=length(na.exclude(length)))
 
+library(mar)
 mar <- connect_mar()
 init.cv <- 
   les_syni(mar) |>

--- a/07-bling/gadget3 - WKBDEEP/00-setup/setup.R
+++ b/07-bling/gadget3 - WKBDEEP/00-setup/setup.R
@@ -8,6 +8,7 @@ library(mfdb)
 library(gadget3)
 library(gadgetutils)
 library(gadgetplots)
+library(tidyverse)
 #library(g3experiments)
 
 ## Model directory

--- a/07-bling/gadget3 - WKBDEEP/00-setup/setup.R
+++ b/07-bling/gadget3 - WKBDEEP/00-setup/setup.R
@@ -8,7 +8,6 @@ library(mfdb)
 library(gadget3)
 library(gadgetutils)
 library(gadgetplots)
-library(mar)
 #library(g3experiments)
 
 ## Model directory

--- a/07-bling/gadget3 - WKBDEEP/00-setup/setup.R
+++ b/07-bling/gadget3 - WKBDEEP/00-setup/setup.R
@@ -11,7 +11,7 @@ library(gadgetplots)
 #library(g3experiments)
 
 ## Model directory
-base_dir <- 'benchmarks/WKBDEEP/gadget3'
+base_dir <- '07-bling/gadget3 - WKBDEEP'
 
 #load("~/DAG/07-bling/sexr.Rdata")
 


### PR DESCRIPTION
@willbutler42, I've been working recently to improve the gadget3 vignettes, and been noseying around gadget-models for inspiration. Here's some drive-by fixes for you :) The mar one in particular is a bit clunky, but gets the job done at least. It might be better to refer to ``mar::`` explicitly..

This works up until trying to run ``gadget_plots(..., template = 'iceland_bling')``, which I can't find either in gadget-models or gadgetplots. This isn't a big deal for my needs, but dunno if it should be made public at some point.